### PR TITLE
⬆️ Dependency updates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -107,13 +107,13 @@
       "integrity": "sha512-8+coTzRjHQkk/T7UTvX4bTpseyiL41lKzAfVC11b4C3ORKrIOI+uhJFssBb0rGl7N40Epuzxto/2HY8xs4pLsA=="
     },
     "@esri/calcite-components": {
-      "version": "1.0.0-beta.55",
-      "resolved": "https://registry.npmjs.org/@esri/calcite-components/-/calcite-components-1.0.0-beta.55.tgz",
-      "integrity": "sha512-bl/kmKmxZNfahLTLCVuw7MoDT+YOtsdt/l1TL/0ZVgpeAYip/8BCgFoMUZ1o+89o24im7dqQP9aJHsgLh8LdSw==",
+      "version": "1.0.0-beta.56",
+      "resolved": "https://registry.npmjs.org/@esri/calcite-components/-/calcite-components-1.0.0-beta.56.tgz",
+      "integrity": "sha512-p3p796uJ85IqlFmkEVKmDPZGEdHWFxRilLmz6aS2nVDWx3sAD4oct9FYuV+jT6JWQBDBG/Y4YRgTS+F9SwWlLg==",
       "requires": {
         "@a11y/focus-trap": "1.0.5",
         "@popperjs/core": "2.9.2",
-        "@stencil/core": "2.5.2",
+        "@stencil/core": "2.6.0",
         "@types/color": "3.0.1",
         "color": "3.1.3",
         "lodash-es": "4.17.21",
@@ -159,9 +159,9 @@
       "integrity": "sha512-cPqjjzuFWNK3BSKLm0abspP0sp/IGOli4p5I5fKFAzdS8fvjdOwDCfZqAaIiXd9lPkOWi3SUUfZof3hEb7J/uw=="
     },
     "@stencil/core": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-2.5.2.tgz",
-      "integrity": "sha512-bgjPXkSzzg1WnTgVUm6m5ZzpKt602WmA/QljODAW1xVN40OHJdbGblzF/F6MFzqv2c5Cy30CB41arc8qADIdcQ=="
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-2.6.0.tgz",
+      "integrity": "sha512-QsxWayZyusnqSZrlCl81R71rA3KqFjVVQSH4E0rGN15F1GdQaFonKlHLyCOLKLig1zzC+DQkLLiUuocexuvdeQ=="
     },
     "@types/color": {
       "version": "3.0.1",
@@ -197,13 +197,13 @@
       "dev": true
     },
     "@typescript-eslint/eslint-plugin": {
-      "version": "4.26.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.26.0.tgz",
-      "integrity": "sha512-yA7IWp+5Qqf+TLbd8b35ySFOFzUfL7i+4If50EqvjT6w35X8Lv0eBHb6rATeWmucks37w+zV+tWnOXI9JlG6Eg==",
+      "version": "4.27.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.27.0.tgz",
+      "integrity": "sha512-DsLqxeUfLVNp3AO7PC3JyaddmEHTtI9qTSAs+RB6ja27QvIM0TA8Cizn1qcS6vOu+WDLFJzkwkgweiyFhssDdQ==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/experimental-utils": "4.26.0",
-        "@typescript-eslint/scope-manager": "4.26.0",
+        "@typescript-eslint/experimental-utils": "4.27.0",
+        "@typescript-eslint/scope-manager": "4.27.0",
         "debug": "^4.3.1",
         "functional-red-black-tree": "^1.0.1",
         "lodash": "^4.17.21",
@@ -213,15 +213,15 @@
       }
     },
     "@typescript-eslint/experimental-utils": {
-      "version": "4.26.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-4.26.0.tgz",
-      "integrity": "sha512-TH2FO2rdDm7AWfAVRB5RSlbUhWxGVuxPNzGT7W65zVfl8H/WeXTk1e69IrcEVsBslrQSTDKQSaJD89hwKrhdkw==",
+      "version": "4.27.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-4.27.0.tgz",
+      "integrity": "sha512-n5NlbnmzT2MXlyT+Y0Jf0gsmAQzCnQSWXKy4RGSXVStjDvS5we9IWbh7qRVKdGcxT0WYlgcCYUK/HRg7xFhvjQ==",
       "dev": true,
       "requires": {
         "@types/json-schema": "^7.0.7",
-        "@typescript-eslint/scope-manager": "4.26.0",
-        "@typescript-eslint/types": "4.26.0",
-        "@typescript-eslint/typescript-estree": "4.26.0",
+        "@typescript-eslint/scope-manager": "4.27.0",
+        "@typescript-eslint/types": "4.27.0",
+        "@typescript-eslint/typescript-estree": "4.27.0",
         "eslint-scope": "^5.1.1",
         "eslint-utils": "^3.0.0"
       },
@@ -238,41 +238,41 @@
       }
     },
     "@typescript-eslint/parser": {
-      "version": "4.26.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-4.26.0.tgz",
-      "integrity": "sha512-b4jekVJG9FfmjUfmM4VoOItQhPlnt6MPOBUL0AQbiTmm+SSpSdhHYlwayOm4IW9KLI/4/cRKtQCmDl1oE2OlPg==",
+      "version": "4.27.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-4.27.0.tgz",
+      "integrity": "sha512-XpbxL+M+gClmJcJ5kHnUpBGmlGdgNvy6cehgR6ufyxkEJMGP25tZKCaKyC0W/JVpuhU3VU1RBn7SYUPKSMqQvQ==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/scope-manager": "4.26.0",
-        "@typescript-eslint/types": "4.26.0",
-        "@typescript-eslint/typescript-estree": "4.26.0",
+        "@typescript-eslint/scope-manager": "4.27.0",
+        "@typescript-eslint/types": "4.27.0",
+        "@typescript-eslint/typescript-estree": "4.27.0",
         "debug": "^4.3.1"
       }
     },
     "@typescript-eslint/scope-manager": {
-      "version": "4.26.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.26.0.tgz",
-      "integrity": "sha512-G6xB6mMo4xVxwMt5lEsNTz3x4qGDt0NSGmTBNBPJxNsrTXJSm21c6raeYroS2OwQsOyIXqKZv266L/Gln1BWqg==",
+      "version": "4.27.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.27.0.tgz",
+      "integrity": "sha512-DY73jK6SEH6UDdzc6maF19AHQJBFVRf6fgAXHPXCGEmpqD4vYgPEzqpFz1lf/daSbOcMpPPj9tyXXDPW2XReAw==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "4.26.0",
-        "@typescript-eslint/visitor-keys": "4.26.0"
+        "@typescript-eslint/types": "4.27.0",
+        "@typescript-eslint/visitor-keys": "4.27.0"
       }
     },
     "@typescript-eslint/types": {
-      "version": "4.26.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.26.0.tgz",
-      "integrity": "sha512-rADNgXl1kS/EKnDr3G+m7fB9yeJNnR9kF7xMiXL6mSIWpr3Wg5MhxyfEXy/IlYthsqwBqHOr22boFbf/u6O88A==",
+      "version": "4.27.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.27.0.tgz",
+      "integrity": "sha512-I4ps3SCPFCKclRcvnsVA/7sWzh7naaM/b4pBO2hVxnM3wrU51Lveybdw5WoIktU/V4KfXrTt94V9b065b/0+wA==",
       "dev": true
     },
     "@typescript-eslint/typescript-estree": {
-      "version": "4.26.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.26.0.tgz",
-      "integrity": "sha512-GHUgahPcm9GfBuy3TzdsizCcPjKOAauG9xkz9TR8kOdssz2Iz9jRCSQm6+aVFa23d5NcSpo1GdHGSQKe0tlcbg==",
+      "version": "4.27.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.27.0.tgz",
+      "integrity": "sha512-KH03GUsUj41sRLLEy2JHstnezgpS5VNhrJouRdmh6yNdQ+yl8w5LrSwBkExM+jWwCJa7Ct2c8yl8NdtNRyQO6g==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "4.26.0",
-        "@typescript-eslint/visitor-keys": "4.26.0",
+        "@typescript-eslint/types": "4.27.0",
+        "@typescript-eslint/visitor-keys": "4.27.0",
         "debug": "^4.3.1",
         "globby": "^11.0.3",
         "is-glob": "^4.0.1",
@@ -281,12 +281,12 @@
       }
     },
     "@typescript-eslint/visitor-keys": {
-      "version": "4.26.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.26.0.tgz",
-      "integrity": "sha512-cw4j8lH38V1ycGBbF+aFiLUls9Z0Bw8QschP3mkth50BbWzgFS33ISIgBzUMuQ2IdahoEv/rXstr8Zhlz4B1Zg==",
+      "version": "4.27.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.27.0.tgz",
+      "integrity": "sha512-es0GRYNZp0ieckZ938cEANfEhsfHrzuLrePukLKtY3/KPXcq1Xd555Mno9/GOgXhKzn0QfkDLVgqWO3dGY80bg==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "4.26.0",
+        "@typescript-eslint/types": "4.27.0",
         "eslint-visitor-keys": "^2.0.0"
       }
     },
@@ -638,9 +638,9 @@
       }
     },
     "esbuild": {
-      "version": "0.12.6",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.12.6.tgz",
-      "integrity": "sha512-RDvVLvAjsq/kIZJoneMiUOH7EE7t2QaW7T3Q7EdQij14+bZbDq5sndb0tTanmHIFSqZVMBMMyqzVHkS3dJobeA==",
+      "version": "0.12.8",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.12.8.tgz",
+      "integrity": "sha512-sx/LwlP/SWTGsd9G4RlOPrXnIihAJ2xwBUmzoqe2nWwbXORMQWtAGNJNYLBJJqa3e9PWvVzxdrtyFZJcr7D87g==",
       "dev": true
     },
     "escape-string-regexp": {
@@ -1696,9 +1696,9 @@
       }
     },
     "postcss": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.3.0.tgz",
-      "integrity": "sha512-+ogXpdAjWGa+fdYY5BQ96V/6tAo+TdSSIMP5huJBIygdWwKtVoB5JWZ7yUd4xZ8r+8Kvvx4nyg/PQ071H4UtcQ==",
+      "version": "8.3.4",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.3.4.tgz",
+      "integrity": "sha512-/tZY0PXExXXnNhKv3TOvZAOUYRyuqcCbBm2c17YMDK0PlVII3K7/LKdt3ScHL+hhouddjUWi+1sKDf9xXW+8YA==",
       "dev": true,
       "requires": {
         "colorette": "^1.2.2",
@@ -1821,9 +1821,9 @@
       }
     },
     "rollup": {
-      "version": "2.51.0",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.51.0.tgz",
-      "integrity": "sha512-ITLt9sScNCBVspSHauw/W49lEZ0vjN8LyCzSNsNaqT67vTss2lYEfOyxltX8hjrhr1l/rQwmZ2wazzEqhZ/fUg==",
+      "version": "2.51.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.51.2.tgz",
+      "integrity": "sha512-ReV2eGEadA7hmXSzjxdDKs10neqH2QURf2RxJ6ayAlq93ugy6qIvXMmbc5cWMGCDh1h5T4thuWO1e2VNbMq8FA==",
       "dev": true,
       "requires": {
         "fsevents": "~2.3.1"
@@ -2170,14 +2170,14 @@
       }
     },
     "vite": {
-      "version": "2.3.6",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-2.3.6.tgz",
-      "integrity": "sha512-fsEpNKDHgh3Sn66JH06ZnUBnIgUVUtw6ucDhlOj1CEqxIkymU25yv1/kWDPlIjyYHnalr0cN6V+zzUJ+fmWHYw==",
+      "version": "2.3.7",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-2.3.7.tgz",
+      "integrity": "sha512-Y0xRz11MPYu/EAvzN94+FsOZHbSvO6FUvHv127CyG7mV6oDoay2bw+g5y9wW3Blf8OY3chaz3nc/DcRe1IQ3Nw==",
       "dev": true,
       "requires": {
         "esbuild": "^0.12.5",
         "fsevents": "~2.3.1",
-        "postcss": "^8.2.10",
+        "postcss": "^8.3.0",
         "resolve": "^1.19.0",
         "rollup": "^2.38.5"
       }

--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
     "serve": "vite preview"
   },
   "devDependencies": {
-    "@typescript-eslint/eslint-plugin": "^4.26.0",
-    "@typescript-eslint/parser": "^4.26.0",
+    "@typescript-eslint/eslint-plugin": "^4.27.0",
+    "@typescript-eslint/parser": "^4.27.0",
     "eslint": "^7.28.0",
     "eslint-config-prettier": "^8.3.0",
     "eslint-config-standard": "^16.0.3",
@@ -19,10 +19,10 @@
     "eslint-plugin-promise": "^5.1.0",
     "prettier": "2.3.1",
     "typescript": "^4.3.2",
-    "vite": "^2.3.6"
+    "vite": "^2.3.7"
   },
   "dependencies": {
     "@arcgis/core": "^4.19.3",
-    "@esri/calcite-components": "^1.0.0-beta.55"
+    "@esri/calcite-components": "^1.0.0-beta.56"
   }
 }


### PR DESCRIPTION
 @typescript-eslint/eslint-plugin         ^4.26.0  →         ^4.27.0
 @typescript-eslint/parser                  ^4.26.0  →         ^4.27.0
 vite                                                    ^2.3.6  →          ^2.3.7
 @esri/calcite-components                ^1.0.0-beta.55  →  ^1.0.0-beta.56