### PR TITLE
⬆️ Update dependencies 20210706

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@
     <link
       id="theme"
       rel="stylesheet"
-      href="https://cdn.jsdelivr.net/npm/@arcgis/core@4.19.3/assets/esri/themes/dark/main.css"
+      href="https://cdn.jsdelivr.net/npm/@arcgis/core@4.20.1/assets/esri/themes/dark/main.css"
     />
     <link
       rel="stylesheet"

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,16 +10,33 @@
       "integrity": "sha512-3JOd6g+BALysWS8LNf0qdB8ltR651H/RCLAvUmfS0LIHwHO579XfjZUIZbURYiAZrcbp1CBAq4QZ2YwKNQZ1hw=="
     },
     "@arcgis/core": {
-      "version": "4.19.3",
-      "resolved": "https://registry.npmjs.org/@arcgis/core/-/core-4.19.3.tgz",
-      "integrity": "sha512-dDNpp8fG09ZkyKlDcJmDaVRQHSRyw7hoOA8WvdmjZ8uRyppmPYrIgbFc/+Dd4RXsZFxClwu0qOzO46+jl24NWg==",
+      "version": "4.20.1",
+      "resolved": "https://registry.npmjs.org/@arcgis/core/-/core-4.20.1.tgz",
+      "integrity": "sha512-/1l0ZfYsXBT3yH8qr4m2JB14sEUD6sgFdfIWcaR9YgZ9Q00AtH7hw3oOIZxiKERwiRrdQtKkUHrjtAEqNGPc6w==",
       "requires": {
-        "@esri/arcgis-html-sanitizer": "~2.5.0",
-        "@esri/calcite-colors": "~5.0.0",
-        "@popperjs/core": "~2.6.0",
-        "focus-trap": "~6.3.0",
+        "@esri/arcgis-html-sanitizer": "~2.6.1",
+        "@esri/calcite-colors": "~6.0.0",
+        "@esri/calcite-components": "1.0.0-beta.56",
+        "@popperjs/core": "~2.9.2",
+        "focus-trap": "~6.5.1",
         "moment": "~2.29.1",
         "sortablejs": "~1.13.0"
+      },
+      "dependencies": {
+        "@esri/calcite-components": {
+          "version": "1.0.0-beta.56",
+          "resolved": "https://registry.npmjs.org/@esri/calcite-components/-/calcite-components-1.0.0-beta.56.tgz",
+          "integrity": "sha512-p3p796uJ85IqlFmkEVKmDPZGEdHWFxRilLmz6aS2nVDWx3sAD4oct9FYuV+jT6JWQBDBG/Y4YRgTS+F9SwWlLg==",
+          "requires": {
+            "@a11y/focus-trap": "1.0.5",
+            "@popperjs/core": "2.9.2",
+            "@stencil/core": "2.6.0",
+            "@types/color": "3.0.1",
+            "color": "3.1.3",
+            "lodash-es": "4.17.21",
+            "sortablejs": "1.13.0"
+          }
+        }
       }
     },
     "@babel/code-frame": {
@@ -93,18 +110,18 @@
       }
     },
     "@esri/arcgis-html-sanitizer": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@esri/arcgis-html-sanitizer/-/arcgis-html-sanitizer-2.5.0.tgz",
-      "integrity": "sha512-axq4dGwm3bjY/iR1DoPxrnJOt2SKXD0Cy1QYihK4yZx25CEDpfdSUBE71oz77BSYFz+KQZvh6A3xxOgLnVEoWA==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@esri/arcgis-html-sanitizer/-/arcgis-html-sanitizer-2.6.1.tgz",
+      "integrity": "sha512-dB0kFaRxIh4YSR6P5+jhkRm1UD4HxnexSOz3D1sgDiTq41YgWezMSIrifO/M83JwpTKd0U28qEf8hKepmldvZg==",
       "requires": {
         "lodash.isplainobject": "^4.0.6",
-        "xss": "^1.0.8"
+        "xss": "^1.0.9"
       }
     },
     "@esri/calcite-colors": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@esri/calcite-colors/-/calcite-colors-5.0.0.tgz",
-      "integrity": "sha512-8+coTzRjHQkk/T7UTvX4bTpseyiL41lKzAfVC11b4C3ORKrIOI+uhJFssBb0rGl7N40Epuzxto/2HY8xs4pLsA=="
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@esri/calcite-colors/-/calcite-colors-6.0.0.tgz",
+      "integrity": "sha512-xsCRLwYHZ9wKFu4zhLTDXk28/wPiEVK4BDHwTr8o+AHCygoNfO2k9JjFP150avS53fldDOVqlEB+D0rr+CI5+w=="
     },
     "@esri/calcite-components": {
       "version": "1.0.0-beta.58",
@@ -126,6 +143,23 @@
           "integrity": "sha512-VZMYa7+fXHdwIq1TDhSXoVmSPEGM/aa+6Aiq3nVVJ9bXr24zScr+NlKFKC3iPljA7ho/GAZr+d2jOf5GIRC30Q=="
         }
       }
+    },
+    "@humanwhocodes/config-array": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.5.0.tgz",
+      "integrity": "sha512-FagtKFz74XrTl7y6HCzQpwDfXP0yhxe9lHLD1UZxjvZIcbyRz8zTFF/yYNfSfzU414eDwZ1SrO0Qvtyf+wFMQg==",
+      "dev": true,
+      "requires": {
+        "@humanwhocodes/object-schema": "^1.2.0",
+        "debug": "^4.1.1",
+        "minimatch": "^3.0.4"
+      }
+    },
+    "@humanwhocodes/object-schema": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.0.tgz",
+      "integrity": "sha512-wdppn25U8z/2yiaT6YGquE6X8sSv7hNMWSXYSSU1jGv/yd6XqjXgTDJ8KP4NgjTXfJ3GbRjeeb8RTV7a/VpM+w==",
+      "dev": true
     },
     "@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -154,9 +188,9 @@
       }
     },
     "@popperjs/core": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.6.0.tgz",
-      "integrity": "sha512-cPqjjzuFWNK3BSKLm0abspP0sp/IGOli4p5I5fKFAzdS8fvjdOwDCfZqAaIiXd9lPkOWi3SUUfZof3hEb7J/uw=="
+      "version": "2.9.2",
+      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.9.2.tgz",
+      "integrity": "sha512-VZMYa7+fXHdwIq1TDhSXoVmSPEGM/aa+6Aiq3nVVJ9bXr24zScr+NlKFKC3iPljA7ho/GAZr+d2jOf5GIRC30Q=="
     },
     "@stencil/core": {
       "version": "2.6.0",
@@ -197,13 +231,13 @@
       "dev": true
     },
     "@typescript-eslint/eslint-plugin": {
-      "version": "4.28.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.28.1.tgz",
-      "integrity": "sha512-9yfcNpDaNGQ6/LQOX/KhUFTR1sCKH+PBr234k6hI9XJ0VP5UqGxap0AnNwBnWFk1MNyWBylJH9ZkzBXC+5akZQ==",
+      "version": "4.28.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.28.2.tgz",
+      "integrity": "sha512-PGqpLLzHSxq956rzNGasO3GsAPf2lY9lDUBXhS++SKonglUmJypaUtcKzRtUte8CV7nruwnDxtLUKpVxs0wQBw==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/experimental-utils": "4.28.1",
-        "@typescript-eslint/scope-manager": "4.28.1",
+        "@typescript-eslint/experimental-utils": "4.28.2",
+        "@typescript-eslint/scope-manager": "4.28.2",
         "debug": "^4.3.1",
         "functional-red-black-tree": "^1.0.1",
         "regexpp": "^3.1.0",
@@ -212,15 +246,15 @@
       }
     },
     "@typescript-eslint/experimental-utils": {
-      "version": "4.28.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-4.28.1.tgz",
-      "integrity": "sha512-n8/ggadrZ+uyrfrSEchx3jgODdmcx7MzVM2sI3cTpI/YlfSm0+9HEUaWw3aQn2urL2KYlWYMDgn45iLfjDYB+Q==",
+      "version": "4.28.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-4.28.2.tgz",
+      "integrity": "sha512-MwHPsL6qo98RC55IoWWP8/opTykjTp4JzfPu1VfO2Z0MshNP0UZ1GEV5rYSSnZSUI8VD7iHvtIPVGW5Nfh7klQ==",
       "dev": true,
       "requires": {
         "@types/json-schema": "^7.0.7",
-        "@typescript-eslint/scope-manager": "4.28.1",
-        "@typescript-eslint/types": "4.28.1",
-        "@typescript-eslint/typescript-estree": "4.28.1",
+        "@typescript-eslint/scope-manager": "4.28.2",
+        "@typescript-eslint/types": "4.28.2",
+        "@typescript-eslint/typescript-estree": "4.28.2",
         "eslint-scope": "^5.1.1",
         "eslint-utils": "^3.0.0"
       },
@@ -237,41 +271,41 @@
       }
     },
     "@typescript-eslint/parser": {
-      "version": "4.28.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-4.28.1.tgz",
-      "integrity": "sha512-UjrMsgnhQIIK82hXGaD+MCN8IfORS1CbMdu7VlZbYa8LCZtbZjJA26De4IPQB7XYZbL8gJ99KWNj0l6WD0guJg==",
+      "version": "4.28.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-4.28.2.tgz",
+      "integrity": "sha512-Q0gSCN51eikAgFGY+gnd5p9bhhCUAl0ERMiDKrTzpSoMYRubdB8MJrTTR/BBii8z+iFwz8oihxd0RAdP4l8w8w==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/scope-manager": "4.28.1",
-        "@typescript-eslint/types": "4.28.1",
-        "@typescript-eslint/typescript-estree": "4.28.1",
+        "@typescript-eslint/scope-manager": "4.28.2",
+        "@typescript-eslint/types": "4.28.2",
+        "@typescript-eslint/typescript-estree": "4.28.2",
         "debug": "^4.3.1"
       }
     },
     "@typescript-eslint/scope-manager": {
-      "version": "4.28.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.28.1.tgz",
-      "integrity": "sha512-o95bvGKfss6705x7jFGDyS7trAORTy57lwJ+VsYwil/lOUxKQ9tA7Suuq+ciMhJc/1qPwB3XE2DKh9wubW8YYA==",
+      "version": "4.28.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.28.2.tgz",
+      "integrity": "sha512-MqbypNjIkJFEFuOwPWNDjq0nqXAKZvDNNs9yNseoGBB1wYfz1G0WHC2AVOy4XD7di3KCcW3+nhZyN6zruqmp2A==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "4.28.1",
-        "@typescript-eslint/visitor-keys": "4.28.1"
+        "@typescript-eslint/types": "4.28.2",
+        "@typescript-eslint/visitor-keys": "4.28.2"
       }
     },
     "@typescript-eslint/types": {
-      "version": "4.28.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.28.1.tgz",
-      "integrity": "sha512-4z+knEihcyX7blAGi7O3Fm3O6YRCP+r56NJFMNGsmtdw+NCdpG5SgNz427LS9nQkRVTswZLhz484hakQwB8RRg==",
+      "version": "4.28.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.28.2.tgz",
+      "integrity": "sha512-Gr15fuQVd93uD9zzxbApz3wf7ua3yk4ZujABZlZhaxxKY8ojo448u7XTm/+ETpy0V0dlMtj6t4VdDvdc0JmUhA==",
       "dev": true
     },
     "@typescript-eslint/typescript-estree": {
-      "version": "4.28.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.28.1.tgz",
-      "integrity": "sha512-GhKxmC4sHXxHGJv8e8egAZeTZ6HI4mLU6S7FUzvFOtsk7ZIDN1ksA9r9DyOgNqowA9yAtZXV0Uiap61bIO81FQ==",
+      "version": "4.28.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.28.2.tgz",
+      "integrity": "sha512-86lLstLvK6QjNZjMoYUBMMsULFw0hPHJlk1fzhAVoNjDBuPVxiwvGuPQq3fsBMCxuDJwmX87tM/AXoadhHRljg==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "4.28.1",
-        "@typescript-eslint/visitor-keys": "4.28.1",
+        "@typescript-eslint/types": "4.28.2",
+        "@typescript-eslint/visitor-keys": "4.28.2",
         "debug": "^4.3.1",
         "globby": "^11.0.3",
         "is-glob": "^4.0.1",
@@ -280,12 +314,12 @@
       }
     },
     "@typescript-eslint/visitor-keys": {
-      "version": "4.28.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.28.1.tgz",
-      "integrity": "sha512-K4HMrdFqr9PFquPu178SaSb92CaWe2yErXyPumc8cYWxFmhgJsNY9eSePmO05j0JhBvf2Cdhptd6E6Yv9HVHcg==",
+      "version": "4.28.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.28.2.tgz",
+      "integrity": "sha512-aT2B4PLyyRDUVUafXzpZFoc0C9t0za4BJAKP5sgWIhG+jHECQZUEjuQSCIwZdiJJ4w4cgu5r3Kh20SOdtEBl0w==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "4.28.1",
+        "@typescript-eslint/types": "4.28.2",
         "eslint-visitor-keys": "^2.0.0"
       }
     },
@@ -536,9 +570,9 @@
       "integrity": "sha1-xtJnJjKi5cg+AT5oZKQs6N79IK4="
     },
     "debug": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
-      "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
+      "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
       "dev": true,
       "requires": {
         "ms": "2.1.2"
@@ -637,9 +671,9 @@
       }
     },
     "esbuild": {
-      "version": "0.12.9",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.12.9.tgz",
-      "integrity": "sha512-MWRhAbMOJ9RJygCrt778rz/qNYgA4ZVj6aXnNPxFjs7PmIpb0fuB9Gmg5uWrr6n++XKwwm/RmSz6RR5JL2Ocsw==",
+      "version": "0.12.15",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.12.15.tgz",
+      "integrity": "sha512-72V4JNd2+48eOVCXx49xoSWHgC3/cCy96e7mbXKY+WOWghN00cCmlGnwVLRhRHorvv0dgCyuMYBZlM2xDM5OQw==",
       "dev": true
     },
     "escape-string-regexp": {
@@ -649,13 +683,14 @@
       "dev": true
     },
     "eslint": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.29.0.tgz",
-      "integrity": "sha512-82G/JToB9qIy/ArBzIWG9xvvwL3R86AlCjtGw+A29OMZDqhTybz/MByORSukGxeI+YPCR4coYyITKk8BFH9nDA==",
+      "version": "7.30.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.30.0.tgz",
+      "integrity": "sha512-VLqz80i3as3NdloY44BQSJpFw534L9Oh+6zJOUaViV4JPd+DaHwutqP7tcpkW3YiXbK6s05RZl7yl7cQn+lijg==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "7.12.11",
         "@eslint/eslintrc": "^0.4.2",
+        "@humanwhocodes/config-array": "^0.5.0",
         "ajv": "^6.10.0",
         "chalk": "^4.0.0",
         "cross-spawn": "^7.0.2",
@@ -1010,9 +1045,9 @@
       "dev": true
     },
     "fastq": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.11.0.tgz",
-      "integrity": "sha512-7Eczs8gIPDrVzT+EksYBcupqMyxSHXXrHOLRRxU2/DicV8789MRBRR8+Hc2uWzUupOs4YS4JzBmBxjjCVBxD/g==",
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.11.1.tgz",
+      "integrity": "sha512-HOnr8Mc60eNYl1gzwp6r5RoUyAn5/glBolUzP/Ez6IFVPMPirxn/9phgL6zhOtaTy7ISwPvQ+wT+hfcRZh/bzw==",
       "dev": true,
       "requires": {
         "reusify": "^1.0.4"
@@ -1056,17 +1091,17 @@
       }
     },
     "flatted": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.1.1.tgz",
-      "integrity": "sha512-zAoAQiudy+r5SvnSw3KJy5os/oRJYHzrzja/tBDqrZtNhUw8bt6y8OBzMWcjWr+8liV8Eb6yOhw8WZ7VFZ5ZzA==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.0.tgz",
+      "integrity": "sha512-XprP7lDrVT+kE2c2YlfiV+IfS9zxukiIOvNamPNsImNhXadSsQEbosItdL9bUQlCZXR13SvPk20BjWSWLA7m4A==",
       "dev": true
     },
     "focus-trap": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-6.3.0.tgz",
-      "integrity": "sha512-BBzvFfkPg5PqrVVCdQ1YOIVNKGvqG9YNVkiAUQFuDM66N8J9uADhs6mlYKrd30ofDJIzEniBnBKM7GO45iCzKQ==",
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-6.5.1.tgz",
+      "integrity": "sha512-q57JebeQXVThn9DWvWLP2rUwuArvk8w3PyqZLSddto0thmVmklFzYJQO97Aq3pUcWkTXjflUa88fT0CrASsaHQ==",
       "requires": {
-        "tabbable": "^5.1.5"
+        "tabbable": "^5.2.0"
       }
     },
     "fs.realpath": {
@@ -1813,9 +1848,9 @@
       }
     },
     "rollup": {
-      "version": "2.52.2",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.52.2.tgz",
-      "integrity": "sha512-4RlFC3k2BIHlUsJ9mGd8OO+9Lm2eDF5P7+6DNQOp5sx+7N/1tFM01kELfbxlMX3MxT6owvLB1ln4S3QvvQlbUA==",
+      "version": "2.52.7",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.52.7.tgz",
+      "integrity": "sha512-55cSH4CCU6MaPr9TAOyrIC+7qFCHscL7tkNsm1MBfIJRRqRbCEY0mmeFn4Wg8FKsHtEH8r389Fz38r/o+kgXLg==",
       "dev": true,
       "requires": {
         "fsevents": "~2.3.2"
@@ -2042,9 +2077,9 @@
       },
       "dependencies": {
         "ajv": {
-          "version": "8.6.0",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.6.0.tgz",
-          "integrity": "sha512-cnUG4NSBiM4YFBxgZIj/In3/6KX+rQ2l2YPRVcvAMQGWEPKuXoPIhxzwqh31jA3IPbI4qEOp/5ILI4ynioXsGQ==",
+          "version": "8.6.1",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.6.1.tgz",
+          "integrity": "sha512-42VLtQUOLefAvKFAQIxIZDaThq6om/PrfP0CYk3/vn+y4BMNkKnbli8ON2QCiHov4KkzOSJ/xSoBJdayiiYvVQ==",
           "dev": true,
           "requires": {
             "fast-deep-equal": "^3.1.1",
@@ -2119,9 +2154,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.4.tgz",
-      "integrity": "sha512-uauPG7XZn9F/mo+7MrsRjyvbxFpzemRjKEZXS4AK83oP2KKOJPvb+9cO/gmnv8arWZvhnjVOXz7B49m1l0e9Ew==",
+      "version": "4.3.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.5.tgz",
+      "integrity": "sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA==",
       "dev": true
     },
     "unbox-primitive": {
@@ -2162,14 +2197,14 @@
       }
     },
     "vite": {
-      "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-2.3.8.tgz",
-      "integrity": "sha512-QiEx+iqNnJntSgSF2fWRQvRey9pORIrtNJzNyBJXwc+BdzWs83FQolX84cTBo393cfhObrtWa6180dAa4NLDiQ==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-2.4.1.tgz",
+      "integrity": "sha512-4BpKRis9uxIqPfIEcJ18LTBsamqnDFxTx45CXwagHjNltHa6PFEvf8Pe6OpgIHb0OyWT30OXOSSQvdOaX4OBiQ==",
       "dev": true,
       "requires": {
         "esbuild": "^0.12.8",
         "fsevents": "~2.3.2",
-        "postcss": "^8.3.4",
+        "postcss": "^8.3.5",
         "resolve": "^1.20.0",
         "rollup": "^2.38.5"
       }

--- a/package.json
+++ b/package.json
@@ -8,9 +8,9 @@
     "serve": "vite preview"
   },
   "devDependencies": {
-    "@typescript-eslint/eslint-plugin": "^4.28.1",
-    "@typescript-eslint/parser": "^4.28.1",
-    "eslint": "^7.29.0",
+    "@typescript-eslint/eslint-plugin": "^4.28.2",
+    "@typescript-eslint/parser": "^4.28.2",
+    "eslint": "^7.30.0",
     "eslint-config-prettier": "^8.3.0",
     "eslint-config-standard": "^16.0.3",
     "eslint-plugin-import": "^2.23.4",
@@ -18,11 +18,11 @@
     "eslint-plugin-prettier": "^3.4.0",
     "eslint-plugin-promise": "^5.1.0",
     "prettier": "2.3.2",
-    "typescript": "^4.3.4",
-    "vite": "^2.3.8"
+    "typescript": "^4.3.5",
+    "vite": "^2.4.1"
   },
   "dependencies": {
-    "@arcgis/core": "^4.19.3",
+    "@arcgis/core": "^4.20.1",
     "@esri/calcite-components": "^1.0.0-beta.58"
   }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -16,7 +16,7 @@ import GraphicsLayer from '@arcgis/core/layers/GraphicsLayer'
 
 esriConfig.apiKey = import.meta.env.VITE_ARCGIS_API_KEY as string
 esriConfig.assetsPath =
-  'https://cdn.jsdelivr.net/npm/@arcgis/core@4.19.3/assets'
+  'https://cdn.jsdelivr.net/npm/@arcgis/core@4.20.1/assets'
 
 setAssetPath(
   'https://cdn.jsdelivr.net/npm/@esri/calcite-components@1.0.0-beta.58/dist/calcite/assets'


### PR DESCRIPTION
 @typescript-eslint/eslint-plugin  ^4.28.1  →  ^4.28.2
 @typescript-eslint/parser         ^4.28.1  →  ^4.28.2
 eslint                            ^7.29.0  →  ^7.30.0
 typescript                         ^4.3.4  →   ^4.3.5
 vite                               ^2.3.8  →   ^2.4.1
 @arcgis/core                      ^4.19.3  →  ^4.20.1