### PR TITLE
Update dependencies 20210712

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,11 +8,11 @@
     <link
       id="theme"
       rel="stylesheet"
-      href="https://cdn.jsdelivr.net/npm/@arcgis/core@4.20.1/assets/esri/themes/dark/main.css"
+      href="https://cdn.jsdelivr.net/npm/@arcgis/core@4.20.2/assets/esri/themes/dark/main.css"
     />
     <link
       rel="stylesheet"
-      href="https://cdn.jsdelivr.net/npm/@esri/calcite-components@1.0.0-beta.58/dist/calcite/calcite.css"
+      href="https://cdn.jsdelivr.net/npm/@esri/calcite-components@1.0.0-beta.59/dist/calcite/calcite.css"
     />
   </head>
   <body>

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,9 +10,9 @@
       "integrity": "sha512-3JOd6g+BALysWS8LNf0qdB8ltR651H/RCLAvUmfS0LIHwHO579XfjZUIZbURYiAZrcbp1CBAq4QZ2YwKNQZ1hw=="
     },
     "@arcgis/core": {
-      "version": "4.20.1",
-      "resolved": "https://registry.npmjs.org/@arcgis/core/-/core-4.20.1.tgz",
-      "integrity": "sha512-/1l0ZfYsXBT3yH8qr4m2JB14sEUD6sgFdfIWcaR9YgZ9Q00AtH7hw3oOIZxiKERwiRrdQtKkUHrjtAEqNGPc6w==",
+      "version": "4.20.2",
+      "resolved": "https://registry.npmjs.org/@arcgis/core/-/core-4.20.2.tgz",
+      "integrity": "sha512-LmHNLhJRBri5UpLfmfSFhQ7B3O/lq0B0Qtwkdy3gJUJ1DOZBfo0c5ezpSfqsHjTTDxTxSyMF5fl8Y1H4+UagZQ==",
       "requires": {
         "@esri/arcgis-html-sanitizer": "~2.6.1",
         "@esri/calcite-colors": "~6.0.0",
@@ -124,9 +124,9 @@
       "integrity": "sha512-xsCRLwYHZ9wKFu4zhLTDXk28/wPiEVK4BDHwTr8o+AHCygoNfO2k9JjFP150avS53fldDOVqlEB+D0rr+CI5+w=="
     },
     "@esri/calcite-components": {
-      "version": "1.0.0-beta.58",
-      "resolved": "https://registry.npmjs.org/@esri/calcite-components/-/calcite-components-1.0.0-beta.58.tgz",
-      "integrity": "sha512-DsU9kGGy7ChH5H9aPZcoc+SjQcLFV9k5DHbX+SKjYgTHHnlr7tFalXQBcrN2KIYToLQF+toT61zZdfBjOagD5g==",
+      "version": "1.0.0-beta.59",
+      "resolved": "https://registry.npmjs.org/@esri/calcite-components/-/calcite-components-1.0.0-beta.59.tgz",
+      "integrity": "sha512-e3uuoLHwiF7X++ki57VvqlrlIym99M2fSSQ1yivaedwqPdapBwN4/qCv8nYBwRwHcWFC1Ltf+gHRd/G8qiIc6Q==",
       "requires": {
         "@a11y/focus-trap": "1.0.5",
         "@popperjs/core": "2.9.2",
@@ -135,13 +135,6 @@
         "color": "3.1.3",
         "lodash-es": "4.17.21",
         "sortablejs": "1.13.0"
-      },
-      "dependencies": {
-        "@popperjs/core": {
-          "version": "2.9.2",
-          "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.9.2.tgz",
-          "integrity": "sha512-VZMYa7+fXHdwIq1TDhSXoVmSPEGM/aa+6Aiq3nVVJ9bXr24zScr+NlKFKC3iPljA7ho/GAZr+d2jOf5GIRC30Q=="
-        }
       }
     },
     "@humanwhocodes/config-array": {
@@ -178,9 +171,9 @@
       "dev": true
     },
     "@nodelib/fs.walk": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.7.tgz",
-      "integrity": "sha512-BTIhocbPBSrRmHxOAJFtR18oLhxTtAFDAvL8hY1S3iU8k+E60W/YFs4jrixGzQjMpF4qPXxIQHcjVD9dz1C2QA==",
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
       "dev": true,
       "requires": {
         "@nodelib/fs.scandir": "2.1.5",
@@ -219,9 +212,9 @@
       "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ=="
     },
     "@types/json-schema": {
-      "version": "7.0.7",
-      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.7.tgz",
-      "integrity": "sha512-cxWFQVseBm6O9Gbw1IWb8r6OS4OhSt3hPZLkFApLjM8TEXROBuQGLAH2i2gZpcXdLBIrpXuTDhH7Vbm1iXmNGA==",
+      "version": "7.0.8",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.8.tgz",
+      "integrity": "sha512-YSBPTLTVm2e2OoQIDYx8HaeWJ5tTToLH67kXR7zYNGupXMEHa2++G8k+DczX2cFVgalypqtyZIcU19AFcmOpmg==",
       "dev": true
     },
     "@types/json5": {
@@ -231,13 +224,13 @@
       "dev": true
     },
     "@typescript-eslint/eslint-plugin": {
-      "version": "4.28.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.28.2.tgz",
-      "integrity": "sha512-PGqpLLzHSxq956rzNGasO3GsAPf2lY9lDUBXhS++SKonglUmJypaUtcKzRtUte8CV7nruwnDxtLUKpVxs0wQBw==",
+      "version": "4.28.3",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.28.3.tgz",
+      "integrity": "sha512-jW8sEFu1ZeaV8xzwsfi6Vgtty2jf7/lJmQmDkDruBjYAbx5DA8JtbcMnP0rNPUG+oH5GoQBTSp+9613BzuIpYg==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/experimental-utils": "4.28.2",
-        "@typescript-eslint/scope-manager": "4.28.2",
+        "@typescript-eslint/experimental-utils": "4.28.3",
+        "@typescript-eslint/scope-manager": "4.28.3",
         "debug": "^4.3.1",
         "functional-red-black-tree": "^1.0.1",
         "regexpp": "^3.1.0",
@@ -246,15 +239,15 @@
       }
     },
     "@typescript-eslint/experimental-utils": {
-      "version": "4.28.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-4.28.2.tgz",
-      "integrity": "sha512-MwHPsL6qo98RC55IoWWP8/opTykjTp4JzfPu1VfO2Z0MshNP0UZ1GEV5rYSSnZSUI8VD7iHvtIPVGW5Nfh7klQ==",
+      "version": "4.28.3",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-4.28.3.tgz",
+      "integrity": "sha512-zZYl9TnrxwEPi3FbyeX0ZnE8Hp7j3OCR+ELoUfbwGHGxWnHg9+OqSmkw2MoCVpZksPCZYpQzC559Ee9pJNHTQw==",
       "dev": true,
       "requires": {
         "@types/json-schema": "^7.0.7",
-        "@typescript-eslint/scope-manager": "4.28.2",
-        "@typescript-eslint/types": "4.28.2",
-        "@typescript-eslint/typescript-estree": "4.28.2",
+        "@typescript-eslint/scope-manager": "4.28.3",
+        "@typescript-eslint/types": "4.28.3",
+        "@typescript-eslint/typescript-estree": "4.28.3",
         "eslint-scope": "^5.1.1",
         "eslint-utils": "^3.0.0"
       },
@@ -271,41 +264,41 @@
       }
     },
     "@typescript-eslint/parser": {
-      "version": "4.28.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-4.28.2.tgz",
-      "integrity": "sha512-Q0gSCN51eikAgFGY+gnd5p9bhhCUAl0ERMiDKrTzpSoMYRubdB8MJrTTR/BBii8z+iFwz8oihxd0RAdP4l8w8w==",
+      "version": "4.28.3",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-4.28.3.tgz",
+      "integrity": "sha512-ZyWEn34bJexn/JNYvLQab0Mo5e+qqQNhknxmc8azgNd4XqspVYR5oHq9O11fLwdZMRcj4by15ghSlIEq+H5ltQ==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/scope-manager": "4.28.2",
-        "@typescript-eslint/types": "4.28.2",
-        "@typescript-eslint/typescript-estree": "4.28.2",
+        "@typescript-eslint/scope-manager": "4.28.3",
+        "@typescript-eslint/types": "4.28.3",
+        "@typescript-eslint/typescript-estree": "4.28.3",
         "debug": "^4.3.1"
       }
     },
     "@typescript-eslint/scope-manager": {
-      "version": "4.28.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.28.2.tgz",
-      "integrity": "sha512-MqbypNjIkJFEFuOwPWNDjq0nqXAKZvDNNs9yNseoGBB1wYfz1G0WHC2AVOy4XD7di3KCcW3+nhZyN6zruqmp2A==",
+      "version": "4.28.3",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.28.3.tgz",
+      "integrity": "sha512-/8lMisZ5NGIzGtJB+QizQ5eX4Xd8uxedFfMBXOKuJGP0oaBBVEMbJVddQKDXyyB0bPlmt8i6bHV89KbwOelJiQ==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "4.28.2",
-        "@typescript-eslint/visitor-keys": "4.28.2"
+        "@typescript-eslint/types": "4.28.3",
+        "@typescript-eslint/visitor-keys": "4.28.3"
       }
     },
     "@typescript-eslint/types": {
-      "version": "4.28.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.28.2.tgz",
-      "integrity": "sha512-Gr15fuQVd93uD9zzxbApz3wf7ua3yk4ZujABZlZhaxxKY8ojo448u7XTm/+ETpy0V0dlMtj6t4VdDvdc0JmUhA==",
+      "version": "4.28.3",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.28.3.tgz",
+      "integrity": "sha512-kQFaEsQBQVtA9VGVyciyTbIg7S3WoKHNuOp/UF5RG40900KtGqfoiETWD/v0lzRXc+euVE9NXmfer9dLkUJrkA==",
       "dev": true
     },
     "@typescript-eslint/typescript-estree": {
-      "version": "4.28.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.28.2.tgz",
-      "integrity": "sha512-86lLstLvK6QjNZjMoYUBMMsULFw0hPHJlk1fzhAVoNjDBuPVxiwvGuPQq3fsBMCxuDJwmX87tM/AXoadhHRljg==",
+      "version": "4.28.3",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.28.3.tgz",
+      "integrity": "sha512-YAb1JED41kJsqCQt1NcnX5ZdTA93vKFCMP4lQYG6CFxd0VzDJcKttRlMrlG+1qiWAw8+zowmHU1H0OzjWJzR2w==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "4.28.2",
-        "@typescript-eslint/visitor-keys": "4.28.2",
+        "@typescript-eslint/types": "4.28.3",
+        "@typescript-eslint/visitor-keys": "4.28.3",
         "debug": "^4.3.1",
         "globby": "^11.0.3",
         "is-glob": "^4.0.1",
@@ -314,12 +307,12 @@
       }
     },
     "@typescript-eslint/visitor-keys": {
-      "version": "4.28.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.28.2.tgz",
-      "integrity": "sha512-aT2B4PLyyRDUVUafXzpZFoc0C9t0za4BJAKP5sgWIhG+jHECQZUEjuQSCIwZdiJJ4w4cgu5r3Kh20SOdtEBl0w==",
+      "version": "4.28.3",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.28.3.tgz",
+      "integrity": "sha512-ri1OzcLnk1HH4gORmr1dllxDzzrN6goUIz/P4MHFV0YZJDCADPR3RvYNp0PW2SetKTThar6wlbFTL00hV2Q+fg==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "4.28.2",
+        "@typescript-eslint/types": "4.28.3",
         "eslint-visitor-keys": "^2.0.0"
       }
     },
@@ -1020,9 +1013,9 @@
       "dev": true
     },
     "fast-glob": {
-      "version": "3.2.6",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.6.tgz",
-      "integrity": "sha512-GnLuqj/pvQ7pX8/L4J84nijv6sAnlwvSDpMkJi9i7nPmPxGtRPkBSStfvDW5l6nMdX9VWe+pkKWFTgD+vF2QSQ==",
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.7.tgz",
+      "integrity": "sha512-rYGMRwip6lUMvYD3BTScMwT1HtAs2d71SMv66Vrxs0IekGZEjhM0pcMfjQPnknBt2zeCwQMEupiN02ZP4DiT1Q==",
       "dev": true,
       "requires": {
         "@nodelib/fs.stat": "^2.0.2",
@@ -1848,9 +1841,9 @@
       }
     },
     "rollup": {
-      "version": "2.52.7",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.52.7.tgz",
-      "integrity": "sha512-55cSH4CCU6MaPr9TAOyrIC+7qFCHscL7tkNsm1MBfIJRRqRbCEY0mmeFn4Wg8FKsHtEH8r389Fz38r/o+kgXLg==",
+      "version": "2.53.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.53.1.tgz",
+      "integrity": "sha512-yiTCvcYXZEulNWNlEONOQVlhXA/hgxjelFSjNcrwAAIfYx/xqjSHwqg/cCaWOyFRKr+IQBaXwt723m8tCaIUiw==",
       "dev": true,
       "requires": {
         "fsevents": "~2.3.2"
@@ -2197,9 +2190,9 @@
       }
     },
     "vite": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-2.4.1.tgz",
-      "integrity": "sha512-4BpKRis9uxIqPfIEcJ18LTBsamqnDFxTx45CXwagHjNltHa6PFEvf8Pe6OpgIHb0OyWT30OXOSSQvdOaX4OBiQ==",
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-2.4.2.tgz",
+      "integrity": "sha512-2MifxD2I9fjyDmmEzbULOo3kOUoqX90A58cT6mECxoVQlMYFuijZsPQBuA14mqSwvV3ydUsqnq+BRWXyO9Qa+w==",
       "dev": true,
       "requires": {
         "esbuild": "^0.12.8",

--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
     "serve": "vite preview"
   },
   "devDependencies": {
-    "@typescript-eslint/eslint-plugin": "^4.28.2",
-    "@typescript-eslint/parser": "^4.28.2",
+    "@typescript-eslint/eslint-plugin": "^4.28.3",
+    "@typescript-eslint/parser": "^4.28.3",
     "eslint": "^7.30.0",
     "eslint-config-prettier": "^8.3.0",
     "eslint-config-standard": "^16.0.3",
@@ -19,10 +19,10 @@
     "eslint-plugin-promise": "^5.1.0",
     "prettier": "2.3.2",
     "typescript": "^4.3.5",
-    "vite": "^2.4.1"
+    "vite": "^2.4.2"
   },
   "dependencies": {
-    "@arcgis/core": "^4.20.1",
-    "@esri/calcite-components": "^1.0.0-beta.58"
+    "@arcgis/core": "^4.20.2",
+    "@esri/calcite-components": "^1.0.0-beta.59"
   }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -16,10 +16,10 @@ import GraphicsLayer from '@arcgis/core/layers/GraphicsLayer'
 
 esriConfig.apiKey = import.meta.env.VITE_ARCGIS_API_KEY as string
 esriConfig.assetsPath =
-  'https://cdn.jsdelivr.net/npm/@arcgis/core@4.20.1/assets'
+  'https://cdn.jsdelivr.net/npm/@arcgis/core@4.20.2/assets'
 
 setAssetPath(
-  'https://cdn.jsdelivr.net/npm/@esri/calcite-components@1.0.0-beta.58/dist/calcite/assets'
+  'https://cdn.jsdelivr.net/npm/@esri/calcite-components@1.0.0-beta.59/dist/calcite/assets'
 )
 defineCustomElements()
 


### PR DESCRIPTION
 @typescript-eslint/eslint-plugin         ^4.28.2  →         ^4.28.3
 @typescript-eslint/parser                ^4.28.2  →         ^4.28.3
 vite                                      ^2.4.1  →          ^2.4.2
 @arcgis/core                             ^4.20.1  →         ^4.20.2
 @esri/calcite-components          ^1.0.0-beta.58  →  ^1.0.0-beta.59