### PR TITLE
⬆️ Update dependencies 20210725

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,7 +12,7 @@
     />
     <link
       rel="stylesheet"
-      href="https://cdn.jsdelivr.net/npm/@esri/calcite-components@1.0.0-beta.59/dist/calcite/calcite.css"
+      href="https://cdn.jsdelivr.net/npm/@esri/calcite-components@1.0.0-beta.60/dist/calcite/calcite.css"
     />
   </head>
   <body>

--- a/package-lock.json
+++ b/package-lock.json
@@ -124,17 +124,32 @@
       "integrity": "sha512-xsCRLwYHZ9wKFu4zhLTDXk28/wPiEVK4BDHwTr8o+AHCygoNfO2k9JjFP150avS53fldDOVqlEB+D0rr+CI5+w=="
     },
     "@esri/calcite-components": {
-      "version": "1.0.0-beta.59",
-      "resolved": "https://registry.npmjs.org/@esri/calcite-components/-/calcite-components-1.0.0-beta.59.tgz",
-      "integrity": "sha512-e3uuoLHwiF7X++ki57VvqlrlIym99M2fSSQ1yivaedwqPdapBwN4/qCv8nYBwRwHcWFC1Ltf+gHRd/G8qiIc6Q==",
+      "version": "1.0.0-beta.60",
+      "resolved": "https://registry.npmjs.org/@esri/calcite-components/-/calcite-components-1.0.0-beta.60.tgz",
+      "integrity": "sha512-m4YIMecvWJj1ROgvPzokdaKoaQ5jOmHN3e2TdEKaWMocfmdTZNvS0ZrLGOc9ppARXSc94vkkHedUxKryd1bWFQ==",
       "requires": {
         "@a11y/focus-trap": "1.0.5",
         "@popperjs/core": "2.9.2",
         "@stencil/core": "2.6.0",
-        "@types/color": "3.0.1",
+        "@types/color": "3.0.2",
         "color": "3.1.3",
         "lodash-es": "4.17.21",
-        "sortablejs": "1.13.0"
+        "sortablejs": "1.14.0"
+      },
+      "dependencies": {
+        "@types/color": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/@types/color/-/color-3.0.2.tgz",
+          "integrity": "sha512-INiJl6sfNn8iyC5paxVzqiVUEj2boIlFki02uRTAkKwAj++7aAF+ZfEv/XrIeBa0XI/fTZuDHW8rEEcEVnON+Q==",
+          "requires": {
+            "@types/color-convert": "*"
+          }
+        },
+        "sortablejs": {
+          "version": "1.14.0",
+          "resolved": "https://registry.npmjs.org/sortablejs/-/sortablejs-1.14.0.tgz",
+          "integrity": "sha512-pBXvQCs5/33fdN1/39pPL0NZF20LeRbLQ5jtnheIPN9JQAaufGjKdWduZn4U7wCtVuzKhmRkI0DFYHYRbB2H1w=="
+        }
       }
     },
     "@humanwhocodes/config-array": {
@@ -224,13 +239,13 @@
       "dev": true
     },
     "@typescript-eslint/eslint-plugin": {
-      "version": "4.28.3",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.28.3.tgz",
-      "integrity": "sha512-jW8sEFu1ZeaV8xzwsfi6Vgtty2jf7/lJmQmDkDruBjYAbx5DA8JtbcMnP0rNPUG+oH5GoQBTSp+9613BzuIpYg==",
+      "version": "4.28.4",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.28.4.tgz",
+      "integrity": "sha512-s1oY4RmYDlWMlcV0kKPBaADn46JirZzvvH7c2CtAqxCY96S538JRBAzt83RrfkDheV/+G/vWNK0zek+8TB3Gmw==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/experimental-utils": "4.28.3",
-        "@typescript-eslint/scope-manager": "4.28.3",
+        "@typescript-eslint/experimental-utils": "4.28.4",
+        "@typescript-eslint/scope-manager": "4.28.4",
         "debug": "^4.3.1",
         "functional-red-black-tree": "^1.0.1",
         "regexpp": "^3.1.0",
@@ -239,15 +254,15 @@
       }
     },
     "@typescript-eslint/experimental-utils": {
-      "version": "4.28.3",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-4.28.3.tgz",
-      "integrity": "sha512-zZYl9TnrxwEPi3FbyeX0ZnE8Hp7j3OCR+ELoUfbwGHGxWnHg9+OqSmkw2MoCVpZksPCZYpQzC559Ee9pJNHTQw==",
+      "version": "4.28.4",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-4.28.4.tgz",
+      "integrity": "sha512-OglKWOQRWTCoqMSy6pm/kpinEIgdcXYceIcH3EKWUl4S8xhFtN34GQRaAvTIZB9DD94rW7d/U7tUg3SYeDFNHA==",
       "dev": true,
       "requires": {
         "@types/json-schema": "^7.0.7",
-        "@typescript-eslint/scope-manager": "4.28.3",
-        "@typescript-eslint/types": "4.28.3",
-        "@typescript-eslint/typescript-estree": "4.28.3",
+        "@typescript-eslint/scope-manager": "4.28.4",
+        "@typescript-eslint/types": "4.28.4",
+        "@typescript-eslint/typescript-estree": "4.28.4",
         "eslint-scope": "^5.1.1",
         "eslint-utils": "^3.0.0"
       },
@@ -264,41 +279,41 @@
       }
     },
     "@typescript-eslint/parser": {
-      "version": "4.28.3",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-4.28.3.tgz",
-      "integrity": "sha512-ZyWEn34bJexn/JNYvLQab0Mo5e+qqQNhknxmc8azgNd4XqspVYR5oHq9O11fLwdZMRcj4by15ghSlIEq+H5ltQ==",
+      "version": "4.28.4",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-4.28.4.tgz",
+      "integrity": "sha512-4i0jq3C6n+og7/uCHiE6q5ssw87zVdpUj1k6VlVYMonE3ILdFApEzTWgppSRG4kVNB/5jxnH+gTeKLMNfUelQA==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/scope-manager": "4.28.3",
-        "@typescript-eslint/types": "4.28.3",
-        "@typescript-eslint/typescript-estree": "4.28.3",
+        "@typescript-eslint/scope-manager": "4.28.4",
+        "@typescript-eslint/types": "4.28.4",
+        "@typescript-eslint/typescript-estree": "4.28.4",
         "debug": "^4.3.1"
       }
     },
     "@typescript-eslint/scope-manager": {
-      "version": "4.28.3",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.28.3.tgz",
-      "integrity": "sha512-/8lMisZ5NGIzGtJB+QizQ5eX4Xd8uxedFfMBXOKuJGP0oaBBVEMbJVddQKDXyyB0bPlmt8i6bHV89KbwOelJiQ==",
+      "version": "4.28.4",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.28.4.tgz",
+      "integrity": "sha512-ZJBNs4usViOmlyFMt9X9l+X0WAFcDH7EdSArGqpldXu7aeZxDAuAzHiMAeI+JpSefY2INHrXeqnha39FVqXb8w==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "4.28.3",
-        "@typescript-eslint/visitor-keys": "4.28.3"
+        "@typescript-eslint/types": "4.28.4",
+        "@typescript-eslint/visitor-keys": "4.28.4"
       }
     },
     "@typescript-eslint/types": {
-      "version": "4.28.3",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.28.3.tgz",
-      "integrity": "sha512-kQFaEsQBQVtA9VGVyciyTbIg7S3WoKHNuOp/UF5RG40900KtGqfoiETWD/v0lzRXc+euVE9NXmfer9dLkUJrkA==",
+      "version": "4.28.4",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.28.4.tgz",
+      "integrity": "sha512-3eap4QWxGqkYuEmVebUGULMskR6Cuoc/Wii0oSOddleP4EGx1tjLnZQ0ZP33YRoMDCs5O3j56RBV4g14T4jvww==",
       "dev": true
     },
     "@typescript-eslint/typescript-estree": {
-      "version": "4.28.3",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.28.3.tgz",
-      "integrity": "sha512-YAb1JED41kJsqCQt1NcnX5ZdTA93vKFCMP4lQYG6CFxd0VzDJcKttRlMrlG+1qiWAw8+zowmHU1H0OzjWJzR2w==",
+      "version": "4.28.4",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.28.4.tgz",
+      "integrity": "sha512-z7d8HK8XvCRyN2SNp+OXC2iZaF+O2BTquGhEYLKLx5k6p0r05ureUtgEfo5f6anLkhCxdHtCf6rPM1p4efHYDQ==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "4.28.3",
-        "@typescript-eslint/visitor-keys": "4.28.3",
+        "@typescript-eslint/types": "4.28.4",
+        "@typescript-eslint/visitor-keys": "4.28.4",
         "debug": "^4.3.1",
         "globby": "^11.0.3",
         "is-glob": "^4.0.1",
@@ -307,12 +322,12 @@
       }
     },
     "@typescript-eslint/visitor-keys": {
-      "version": "4.28.3",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.28.3.tgz",
-      "integrity": "sha512-ri1OzcLnk1HH4gORmr1dllxDzzrN6goUIz/P4MHFV0YZJDCADPR3RvYNp0PW2SetKTThar6wlbFTL00hV2Q+fg==",
+      "version": "4.28.4",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.28.4.tgz",
+      "integrity": "sha512-NIAXAdbz1XdOuzqkJHjNKXKj8QQ4cv5cxR/g0uQhCYf/6//XrmfpaYsM7PnBcNbfvTDLUkqQ5TPNm1sozDdTWg==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "4.28.3",
+        "@typescript-eslint/types": "4.28.4",
         "eslint-visitor-keys": "^2.0.0"
       }
     },
@@ -1716,9 +1731,9 @@
       }
     },
     "postcss": {
-      "version": "8.3.5",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.3.5.tgz",
-      "integrity": "sha512-NxTuJocUhYGsMiMFHDUkmjSKT3EdH4/WbGF6GCi1NDGk+vbcUTun4fpbOqaPtD8IIsztA2ilZm2DhYCuyN58gA==",
+      "version": "8.3.6",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.3.6.tgz",
+      "integrity": "sha512-wG1cc/JhRgdqB6WHEuyLTedf3KIRuD0hG6ldkFEZNCjRxiC+3i6kkWUUbiJQayP28iwG35cEmAbe98585BYV0A==",
       "dev": true,
       "requires": {
         "colorette": "^1.2.2",
@@ -1841,9 +1856,9 @@
       }
     },
     "rollup": {
-      "version": "2.53.1",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.53.1.tgz",
-      "integrity": "sha512-yiTCvcYXZEulNWNlEONOQVlhXA/hgxjelFSjNcrwAAIfYx/xqjSHwqg/cCaWOyFRKr+IQBaXwt723m8tCaIUiw==",
+      "version": "2.54.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.54.0.tgz",
+      "integrity": "sha512-RHzvstAVwm9A751NxWIbGPFXs3zL4qe/eYg+N7WwGtIXVLy1cK64MiU37+hXeFm1jqipK6DGgMi6Z2hhPuCC3A==",
       "dev": true,
       "requires": {
         "fsevents": "~2.3.2"
@@ -2190,9 +2205,9 @@
       }
     },
     "vite": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-2.4.2.tgz",
-      "integrity": "sha512-2MifxD2I9fjyDmmEzbULOo3kOUoqX90A58cT6mECxoVQlMYFuijZsPQBuA14mqSwvV3ydUsqnq+BRWXyO9Qa+w==",
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-2.4.3.tgz",
+      "integrity": "sha512-iT6NPeiUUZ2FkzC3eazytOEMRaM4J+xgRQcNcpRcbmfYjakCFP4WKPJpeEz1U5JEKHAtwv3ZBQketQUFhFU3ng==",
       "dev": true,
       "requires": {
         "esbuild": "^0.12.8",

--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
     "serve": "vite preview"
   },
   "devDependencies": {
-    "@typescript-eslint/eslint-plugin": "^4.28.3",
-    "@typescript-eslint/parser": "^4.28.3",
+    "@typescript-eslint/eslint-plugin": "^4.28.4",
+    "@typescript-eslint/parser": "^4.28.4",
     "eslint": "^7.31.0",
     "eslint-config-prettier": "^8.3.0",
     "eslint-config-standard": "^16.0.3",
@@ -19,10 +19,10 @@
     "eslint-plugin-promise": "^5.1.0",
     "prettier": "2.3.2",
     "typescript": "^4.3.5",
-    "vite": "^2.4.2"
+    "vite": "^2.4.3"
   },
   "dependencies": {
     "@arcgis/core": "^4.20.2",
-    "@esri/calcite-components": "^1.0.0-beta.59"
+    "@esri/calcite-components": "^1.0.0-beta.60"
   }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -19,7 +19,7 @@ esriConfig.assetsPath =
   'https://cdn.jsdelivr.net/npm/@arcgis/core@4.20.2/assets'
 
 setAssetPath(
-  'https://cdn.jsdelivr.net/npm/@esri/calcite-components@1.0.0-beta.59/dist/calcite/assets'
+  'https://cdn.jsdelivr.net/npm/@esri/calcite-components@1.0.0-beta.60/dist/calcite/assets'
 )
 defineCustomElements()
 


### PR DESCRIPTION
@typescript-eslint/eslint-plugin         ^4.28.3  →         ^4.28.4
@typescript-eslint/parser                ^4.28.3  →         ^4.28.4
vite                                      ^2.4.2  →          ^2.4.3
@esri/calcite-components          ^1.0.0-beta.59  →  ^1.0.0-beta.60