### PR TITLE
⬆️ Update dependencies 20210802

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,7 +12,7 @@
     />
     <link
       rel="stylesheet"
-      href="https://cdn.jsdelivr.net/npm/@esri/calcite-components@1.0.0-beta.60/dist/calcite/calcite.css"
+      href="https://cdn.jsdelivr.net/npm/@esri/calcite-components@1.0.0-beta.61/dist/calcite/calcite.css"
     />
   </head>
   <body>

--- a/package.json
+++ b/package.json
@@ -8,9 +8,9 @@
     "serve": "vite preview"
   },
   "devDependencies": {
-    "@typescript-eslint/eslint-plugin": "^4.28.4",
-    "@typescript-eslint/parser": "^4.28.4",
-    "eslint": "^7.31.0",
+    "@typescript-eslint/eslint-plugin": "^4.29.0",
+    "@typescript-eslint/parser": "^4.29.0",
+    "eslint": "^7.32.0",
     "eslint-config-prettier": "^8.3.0",
     "eslint-config-standard": "^16.0.3",
     "eslint-plugin-import": "^2.23.4",
@@ -19,10 +19,10 @@
     "eslint-plugin-promise": "^5.1.0",
     "prettier": "2.3.2",
     "typescript": "^4.3.5",
-    "vite": "^2.4.3"
+    "vite": "^2.4.4"
   },
   "dependencies": {
     "@arcgis/core": "^4.20.2",
-    "@esri/calcite-components": "^1.0.0-beta.60"
+    "@esri/calcite-components": "^1.0.0-beta.61"
   }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -19,7 +19,7 @@ esriConfig.assetsPath =
   'https://cdn.jsdelivr.net/npm/@arcgis/core@4.20.2/assets'
 
 setAssetPath(
-  'https://cdn.jsdelivr.net/npm/@esri/calcite-components@1.0.0-beta.60/dist/calcite/assets'
+  'https://cdn.jsdelivr.net/npm/@esri/calcite-components@1.0.0-beta.61/dist/calcite/assets'
 )
 defineCustomElements()
 


### PR DESCRIPTION
@typescript-eslint/eslint-plugin         ^4.28.4  →         ^4.29.0
@typescript-eslint/parser                ^4.28.4  →         ^4.29.0
eslint                                   ^7.31.0  →         ^7.32.0
vite                                      ^2.4.3  →          ^2.4.4
@esri/calcite-components          ^1.0.0-beta.60  →  ^1.0.0-beta.61