### PR TITLE
⬆️ Upgrade dependencies 20220607

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,7 +12,7 @@
     />
     <link
       rel="stylesheet"
-      href="https://cdn.jsdelivr.net/npm/@esri/calcite-components@1.0.0-beta.82/dist/calcite/calcite.css"
+      href="https://cdn.jsdelivr.net/npm/@esri/calcite-components@1.0.0-beta.83/dist/calcite/calcite.css"
     />
   </head>
   <body>

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,14 +9,14 @@
       "version": "0.0.0",
       "dependencies": {
         "@arcgis/core": "^4.23.7",
-        "@esri/calcite-components": "^1.0.0-beta.82"
+        "@esri/calcite-components": "^1.0.0-beta.83"
       },
       "devDependencies": {
-        "@typescript-eslint/eslint-plugin": "^5.25.0",
-        "@typescript-eslint/parser": "^5.25.0",
-        "eslint": "^8.15.0",
-        "typescript": "^4.6.4",
-        "vite": "^2.9.9"
+        "@typescript-eslint/eslint-plugin": "^5.27.1",
+        "@typescript-eslint/parser": "^5.27.1",
+        "eslint": "^8.17.0",
+        "typescript": "^4.7.3",
+        "vite": "^2.9.10"
       }
     },
     "node_modules/@a11y/focus-trap": {
@@ -84,15 +84,15 @@
       }
     },
     "node_modules/@eslint/eslintrc": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.2.3.tgz",
-      "integrity": "sha512-uGo44hIwoLGNyduRpjdEpovcbMdd+Nv7amtmJxnKmI8xj6yd5LncmSwDa5NgX/41lIFJtkjD6YdVfgEzPfJ5UA==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.3.0.tgz",
+      "integrity": "sha512-UWW0TMTmk2d7hLcWD1/e2g5HDM/HQ3csaLSqXCfqwh4uNDuNqlaKWXmEsL4Cs41Z0KnILNvwbHAah3C2yt06kw==",
       "dev": true,
       "dependencies": {
         "ajv": "^6.12.4",
         "debug": "^4.3.2",
         "espree": "^9.3.2",
-        "globals": "^13.9.0",
+        "globals": "^13.15.0",
         "ignore": "^5.2.0",
         "import-fresh": "^3.2.1",
         "js-yaml": "^4.1.0",
@@ -118,13 +118,13 @@
       "integrity": "sha512-iGUIIpeMCJSTDGw4ZsxLwwxkml0QzOUJTtysjRryGbhSt183NEtwWKS+yQO19utXQz5LbQWjoav6x6CsawElkw=="
     },
     "node_modules/@esri/calcite-components": {
-      "version": "1.0.0-beta.82",
-      "resolved": "https://registry.npmjs.org/@esri/calcite-components/-/calcite-components-1.0.0-beta.82.tgz",
-      "integrity": "sha512-wAJeEZ4g/TiJ4J6z/GO9YQFSFubQERCWEo71jr2xLmegxEQIYHL3AvJaLmp0IBsr2tVzRG1TN2PVuew4ljp8WA==",
+      "version": "1.0.0-beta.83",
+      "resolved": "https://registry.npmjs.org/@esri/calcite-components/-/calcite-components-1.0.0-beta.83.tgz",
+      "integrity": "sha512-9IRJNApy0i8Qa7o49aL4hs91pGcdpDwuJb+rlT+PzoqKzerwHfH5bc5Kmbog13i+LPJS79vEOBrRYk9rBKRVJg==",
       "dependencies": {
         "@a11y/focus-trap": "1.0.5",
         "@popperjs/core": "2.11.5",
-        "@stencil/core": "2.15.1",
+        "@stencil/core": "2.16.0",
         "@types/color": "3.0.3",
         "color": "4.2.3",
         "form-request-submit-polyfill": "2.0.0",
@@ -202,9 +202,9 @@
       }
     },
     "node_modules/@stencil/core": {
-      "version": "2.15.1",
-      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-2.15.1.tgz",
-      "integrity": "sha512-NYjRwQnjzscyFfqK+iIwRdr/dgYn33u6KE7kyQWdi7xsCkqMHalXYgJlN/QBQ9PN3qXmXKeBrJNG8EkNdCbK5g==",
+      "version": "2.16.0",
+      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-2.16.0.tgz",
+      "integrity": "sha512-oKxPYxpH1no0oMFSf8EesuFBcn9hVpoqrpiS2WH0H50RKKL8hhKoxDfn/cNeD12L0Aj7kf6nNtexIllmkYG6lw==",
       "bin": {
         "stencil": "bin/stencil"
       },
@@ -241,14 +241,14 @@
       "dev": true
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "5.25.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.25.0.tgz",
-      "integrity": "sha512-icYrFnUzvm+LhW0QeJNKkezBu6tJs9p/53dpPLFH8zoM9w1tfaKzVurkPotEpAqQ8Vf8uaFyL5jHd0Vs6Z0ZQg==",
+      "version": "5.27.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.27.1.tgz",
+      "integrity": "sha512-6dM5NKT57ZduNnJfpY81Phe9nc9wolnMCnknb1im6brWi1RYv84nbMS3olJa27B6+irUVV1X/Wb+Am0FjJdGFw==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "5.25.0",
-        "@typescript-eslint/type-utils": "5.25.0",
-        "@typescript-eslint/utils": "5.25.0",
+        "@typescript-eslint/scope-manager": "5.27.1",
+        "@typescript-eslint/type-utils": "5.27.1",
+        "@typescript-eslint/utils": "5.27.1",
         "debug": "^4.3.4",
         "functional-red-black-tree": "^1.0.1",
         "ignore": "^5.2.0",
@@ -274,14 +274,14 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "5.25.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.25.0.tgz",
-      "integrity": "sha512-r3hwrOWYbNKP1nTcIw/aZoH+8bBnh/Lh1iDHoFpyG4DnCpvEdctrSl6LOo19fZbzypjQMHdajolxs6VpYoChgA==",
+      "version": "5.27.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.27.1.tgz",
+      "integrity": "sha512-7Va2ZOkHi5NP+AZwb5ReLgNF6nWLGTeUJfxdkVUAPPSaAdbWNnFZzLZ4EGGmmiCTg+AwlbE1KyUYTBglosSLHQ==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "5.25.0",
-        "@typescript-eslint/types": "5.25.0",
-        "@typescript-eslint/typescript-estree": "5.25.0",
+        "@typescript-eslint/scope-manager": "5.27.1",
+        "@typescript-eslint/types": "5.27.1",
+        "@typescript-eslint/typescript-estree": "5.27.1",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -301,13 +301,13 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "5.25.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.25.0.tgz",
-      "integrity": "sha512-p4SKTFWj+2VpreUZ5xMQsBMDdQ9XdRvODKXN4EksyBjFp2YvQdLkyHqOffakYZPuWJUDNu3jVXtHALDyTv3cww==",
+      "version": "5.27.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.27.1.tgz",
+      "integrity": "sha512-fQEOSa/QroWE6fAEg+bJxtRZJTH8NTskggybogHt4H9Da8zd4cJji76gA5SBlR0MgtwF7rebxTbDKB49YUCpAg==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "5.25.0",
-        "@typescript-eslint/visitor-keys": "5.25.0"
+        "@typescript-eslint/types": "5.27.1",
+        "@typescript-eslint/visitor-keys": "5.27.1"
       },
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -318,12 +318,12 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "5.25.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.25.0.tgz",
-      "integrity": "sha512-B6nb3GK3Gv1Rsb2pqalebe/RyQoyG/WDy9yhj8EE0Ikds4Xa8RR28nHz+wlt4tMZk5bnAr0f3oC8TuDAd5CPrw==",
+      "version": "5.27.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.27.1.tgz",
+      "integrity": "sha512-+UC1vVUWaDHRnC2cQrCJ4QtVjpjjCgjNFpg8b03nERmkHv9JV9X5M19D7UFMd+/G7T/sgFwX2pGmWK38rqyvXw==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/utils": "5.25.0",
+        "@typescript-eslint/utils": "5.27.1",
         "debug": "^4.3.4",
         "tsutils": "^3.21.0"
       },
@@ -344,9 +344,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "5.25.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.25.0.tgz",
-      "integrity": "sha512-7fWqfxr0KNHj75PFqlGX24gWjdV/FDBABXL5dyvBOWHpACGyveok8Uj4ipPX/1fGU63fBkzSIycEje4XsOxUFA==",
+      "version": "5.27.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.27.1.tgz",
+      "integrity": "sha512-LgogNVkBhCTZU/m8XgEYIWICD6m4dmEDbKXESCbqOXfKZxRKeqpiJXQIErv66sdopRKZPo5l32ymNqibYEH/xg==",
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -357,13 +357,13 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "5.25.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.25.0.tgz",
-      "integrity": "sha512-MrPODKDych/oWs/71LCnuO7NyR681HuBly2uLnX3r5i4ME7q/yBqC4hW33kmxtuauLTM0OuBOhhkFaxCCOjEEw==",
+      "version": "5.27.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.27.1.tgz",
+      "integrity": "sha512-DnZvvq3TAJ5ke+hk0LklvxwYsnXpRdqUY5gaVS0D4raKtbznPz71UJGnPTHEFo0GDxqLOLdMkkmVZjSpET1hFw==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "5.25.0",
-        "@typescript-eslint/visitor-keys": "5.25.0",
+        "@typescript-eslint/types": "5.27.1",
+        "@typescript-eslint/visitor-keys": "5.27.1",
         "debug": "^4.3.4",
         "globby": "^11.1.0",
         "is-glob": "^4.0.3",
@@ -384,15 +384,15 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "5.25.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.25.0.tgz",
-      "integrity": "sha512-qNC9bhnz/n9Kba3yI6HQgQdBLuxDoMgdjzdhSInZh6NaDnFpTUlwNGxplUFWfY260Ya0TRPvkg9dd57qxrJI9g==",
+      "version": "5.27.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.27.1.tgz",
+      "integrity": "sha512-mZ9WEn1ZLDaVrhRaYgzbkXBkTPghPFsup8zDbbsYTxC5OmqrFE7skkKS/sraVsLP3TcT3Ki5CSyEFBRkLH/H/w==",
       "dev": true,
       "dependencies": {
         "@types/json-schema": "^7.0.9",
-        "@typescript-eslint/scope-manager": "5.25.0",
-        "@typescript-eslint/types": "5.25.0",
-        "@typescript-eslint/typescript-estree": "5.25.0",
+        "@typescript-eslint/scope-manager": "5.27.1",
+        "@typescript-eslint/types": "5.27.1",
+        "@typescript-eslint/typescript-estree": "5.27.1",
         "eslint-scope": "^5.1.1",
         "eslint-utils": "^3.0.0"
       },
@@ -408,12 +408,12 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "5.25.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.25.0.tgz",
-      "integrity": "sha512-yd26vFgMsC4h2dgX4+LR+GeicSKIfUvZREFLf3DDjZPtqgLx5AJZr6TetMNwFP9hcKreTTeztQYBTNbNoOycwA==",
+      "version": "5.27.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.27.1.tgz",
+      "integrity": "sha512-xYs6ffo01nhdJgPieyk7HAOpjhTsx7r/oB9LWEhwAXgwn33tkr+W8DI2ChboqhZlC4q3TC6geDYPoiX8ROqyOQ==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "5.25.0",
+        "@typescript-eslint/types": "5.27.1",
         "eslint-visitor-keys": "^3.3.0"
       },
       "engines": {
@@ -1035,12 +1035,12 @@
       }
     },
     "node_modules/eslint": {
-      "version": "8.15.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.15.0.tgz",
-      "integrity": "sha512-GG5USZ1jhCu8HJkzGgeK8/+RGnHaNYZGrGDzUtigK3BsGESW/rs2az23XqE0WVwDxy1VRvvjSSGu5nB0Bu+6SA==",
+      "version": "8.17.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.17.0.tgz",
+      "integrity": "sha512-gq0m0BTJfci60Fz4nczYxNAlED+sMcihltndR8t9t1evnU/azx53x3t2UHXC/uRjcbvRw/XctpaNygSTcQD+Iw==",
       "dev": true,
       "dependencies": {
-        "@eslint/eslintrc": "^1.2.3",
+        "@eslint/eslintrc": "^1.3.0",
         "@humanwhocodes/config-array": "^0.9.2",
         "ajv": "^6.10.0",
         "chalk": "^4.0.0",
@@ -1058,7 +1058,7 @@
         "file-entry-cache": "^6.0.1",
         "functional-red-black-tree": "^1.0.1",
         "glob-parent": "^6.0.1",
-        "globals": "^13.6.0",
+        "globals": "^13.15.0",
         "ignore": "^5.2.0",
         "import-fresh": "^3.0.0",
         "imurmurhash": "^0.1.4",
@@ -2132,9 +2132,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.6.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.4.tgz",
-      "integrity": "sha512-9ia/jWHIEbo49HfjrLGfKbZSuWo9iTMwXO+Ca3pRsSpbsMbc7/IU8NKdCZVRRBafVPGnoJeFL76ZOAA84I9fEg==",
+      "version": "4.7.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.3.tgz",
+      "integrity": "sha512-WOkT3XYvrpXx4vMMqlD+8R8R37fZkjyLGlxavMc4iB8lrl8L0DeTcHbYgw/v0N/z9wAFsgBhcsF0ruoySS22mA==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -2160,9 +2160,9 @@
       "dev": true
     },
     "node_modules/vite": {
-      "version": "2.9.9",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-2.9.9.tgz",
-      "integrity": "sha512-ffaam+NgHfbEmfw/Vuh6BHKKlI/XIAhxE5QSS7gFLIngxg171mg1P3a4LSRME0z2ZU1ScxoKzphkipcYwSD5Ew==",
+      "version": "2.9.10",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-2.9.10.tgz",
+      "integrity": "sha512-TwZRuSMYjpTurLqXspct+HZE7ONiW9d+wSWgvADGxhDPPyoIcNywY+RX4ng+QpK30DCa1l/oZgi2PLZDibhzbQ==",
       "dev": true,
       "dependencies": {
         "esbuild": "^0.14.27",
@@ -2307,15 +2307,15 @@
       }
     },
     "@eslint/eslintrc": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.2.3.tgz",
-      "integrity": "sha512-uGo44hIwoLGNyduRpjdEpovcbMdd+Nv7amtmJxnKmI8xj6yd5LncmSwDa5NgX/41lIFJtkjD6YdVfgEzPfJ5UA==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.3.0.tgz",
+      "integrity": "sha512-UWW0TMTmk2d7hLcWD1/e2g5HDM/HQ3csaLSqXCfqwh4uNDuNqlaKWXmEsL4Cs41Z0KnILNvwbHAah3C2yt06kw==",
       "dev": true,
       "requires": {
         "ajv": "^6.12.4",
         "debug": "^4.3.2",
         "espree": "^9.3.2",
-        "globals": "^13.9.0",
+        "globals": "^13.15.0",
         "ignore": "^5.2.0",
         "import-fresh": "^3.2.1",
         "js-yaml": "^4.1.0",
@@ -2338,13 +2338,13 @@
       "integrity": "sha512-iGUIIpeMCJSTDGw4ZsxLwwxkml0QzOUJTtysjRryGbhSt183NEtwWKS+yQO19utXQz5LbQWjoav6x6CsawElkw=="
     },
     "@esri/calcite-components": {
-      "version": "1.0.0-beta.82",
-      "resolved": "https://registry.npmjs.org/@esri/calcite-components/-/calcite-components-1.0.0-beta.82.tgz",
-      "integrity": "sha512-wAJeEZ4g/TiJ4J6z/GO9YQFSFubQERCWEo71jr2xLmegxEQIYHL3AvJaLmp0IBsr2tVzRG1TN2PVuew4ljp8WA==",
+      "version": "1.0.0-beta.83",
+      "resolved": "https://registry.npmjs.org/@esri/calcite-components/-/calcite-components-1.0.0-beta.83.tgz",
+      "integrity": "sha512-9IRJNApy0i8Qa7o49aL4hs91pGcdpDwuJb+rlT+PzoqKzerwHfH5bc5Kmbog13i+LPJS79vEOBrRYk9rBKRVJg==",
       "requires": {
         "@a11y/focus-trap": "1.0.5",
         "@popperjs/core": "2.11.5",
-        "@stencil/core": "2.15.1",
+        "@stencil/core": "2.16.0",
         "@types/color": "3.0.3",
         "color": "4.2.3",
         "form-request-submit-polyfill": "2.0.0",
@@ -2408,9 +2408,9 @@
       "integrity": "sha512-9X2obfABZuDVLCgPK9aX0a/x4jaOEweTTWE2+9sr0Qqqevj2Uv5XorvusThmc9XGYpS9yI+fhh8RTafBtGposw=="
     },
     "@stencil/core": {
-      "version": "2.15.1",
-      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-2.15.1.tgz",
-      "integrity": "sha512-NYjRwQnjzscyFfqK+iIwRdr/dgYn33u6KE7kyQWdi7xsCkqMHalXYgJlN/QBQ9PN3qXmXKeBrJNG8EkNdCbK5g=="
+      "version": "2.16.0",
+      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-2.16.0.tgz",
+      "integrity": "sha512-oKxPYxpH1no0oMFSf8EesuFBcn9hVpoqrpiS2WH0H50RKKL8hhKoxDfn/cNeD12L0Aj7kf6nNtexIllmkYG6lw=="
     },
     "@types/color": {
       "version": "3.0.3",
@@ -2440,14 +2440,14 @@
       "dev": true
     },
     "@typescript-eslint/eslint-plugin": {
-      "version": "5.25.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.25.0.tgz",
-      "integrity": "sha512-icYrFnUzvm+LhW0QeJNKkezBu6tJs9p/53dpPLFH8zoM9w1tfaKzVurkPotEpAqQ8Vf8uaFyL5jHd0Vs6Z0ZQg==",
+      "version": "5.27.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.27.1.tgz",
+      "integrity": "sha512-6dM5NKT57ZduNnJfpY81Phe9nc9wolnMCnknb1im6brWi1RYv84nbMS3olJa27B6+irUVV1X/Wb+Am0FjJdGFw==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/scope-manager": "5.25.0",
-        "@typescript-eslint/type-utils": "5.25.0",
-        "@typescript-eslint/utils": "5.25.0",
+        "@typescript-eslint/scope-manager": "5.27.1",
+        "@typescript-eslint/type-utils": "5.27.1",
+        "@typescript-eslint/utils": "5.27.1",
         "debug": "^4.3.4",
         "functional-red-black-tree": "^1.0.1",
         "ignore": "^5.2.0",
@@ -2457,52 +2457,52 @@
       }
     },
     "@typescript-eslint/parser": {
-      "version": "5.25.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.25.0.tgz",
-      "integrity": "sha512-r3hwrOWYbNKP1nTcIw/aZoH+8bBnh/Lh1iDHoFpyG4DnCpvEdctrSl6LOo19fZbzypjQMHdajolxs6VpYoChgA==",
+      "version": "5.27.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.27.1.tgz",
+      "integrity": "sha512-7Va2ZOkHi5NP+AZwb5ReLgNF6nWLGTeUJfxdkVUAPPSaAdbWNnFZzLZ4EGGmmiCTg+AwlbE1KyUYTBglosSLHQ==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/scope-manager": "5.25.0",
-        "@typescript-eslint/types": "5.25.0",
-        "@typescript-eslint/typescript-estree": "5.25.0",
+        "@typescript-eslint/scope-manager": "5.27.1",
+        "@typescript-eslint/types": "5.27.1",
+        "@typescript-eslint/typescript-estree": "5.27.1",
         "debug": "^4.3.4"
       }
     },
     "@typescript-eslint/scope-manager": {
-      "version": "5.25.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.25.0.tgz",
-      "integrity": "sha512-p4SKTFWj+2VpreUZ5xMQsBMDdQ9XdRvODKXN4EksyBjFp2YvQdLkyHqOffakYZPuWJUDNu3jVXtHALDyTv3cww==",
+      "version": "5.27.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.27.1.tgz",
+      "integrity": "sha512-fQEOSa/QroWE6fAEg+bJxtRZJTH8NTskggybogHt4H9Da8zd4cJji76gA5SBlR0MgtwF7rebxTbDKB49YUCpAg==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "5.25.0",
-        "@typescript-eslint/visitor-keys": "5.25.0"
+        "@typescript-eslint/types": "5.27.1",
+        "@typescript-eslint/visitor-keys": "5.27.1"
       }
     },
     "@typescript-eslint/type-utils": {
-      "version": "5.25.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.25.0.tgz",
-      "integrity": "sha512-B6nb3GK3Gv1Rsb2pqalebe/RyQoyG/WDy9yhj8EE0Ikds4Xa8RR28nHz+wlt4tMZk5bnAr0f3oC8TuDAd5CPrw==",
+      "version": "5.27.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.27.1.tgz",
+      "integrity": "sha512-+UC1vVUWaDHRnC2cQrCJ4QtVjpjjCgjNFpg8b03nERmkHv9JV9X5M19D7UFMd+/G7T/sgFwX2pGmWK38rqyvXw==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/utils": "5.25.0",
+        "@typescript-eslint/utils": "5.27.1",
         "debug": "^4.3.4",
         "tsutils": "^3.21.0"
       }
     },
     "@typescript-eslint/types": {
-      "version": "5.25.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.25.0.tgz",
-      "integrity": "sha512-7fWqfxr0KNHj75PFqlGX24gWjdV/FDBABXL5dyvBOWHpACGyveok8Uj4ipPX/1fGU63fBkzSIycEje4XsOxUFA==",
+      "version": "5.27.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.27.1.tgz",
+      "integrity": "sha512-LgogNVkBhCTZU/m8XgEYIWICD6m4dmEDbKXESCbqOXfKZxRKeqpiJXQIErv66sdopRKZPo5l32ymNqibYEH/xg==",
       "dev": true
     },
     "@typescript-eslint/typescript-estree": {
-      "version": "5.25.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.25.0.tgz",
-      "integrity": "sha512-MrPODKDych/oWs/71LCnuO7NyR681HuBly2uLnX3r5i4ME7q/yBqC4hW33kmxtuauLTM0OuBOhhkFaxCCOjEEw==",
+      "version": "5.27.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.27.1.tgz",
+      "integrity": "sha512-DnZvvq3TAJ5ke+hk0LklvxwYsnXpRdqUY5gaVS0D4raKtbznPz71UJGnPTHEFo0GDxqLOLdMkkmVZjSpET1hFw==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "5.25.0",
-        "@typescript-eslint/visitor-keys": "5.25.0",
+        "@typescript-eslint/types": "5.27.1",
+        "@typescript-eslint/visitor-keys": "5.27.1",
         "debug": "^4.3.4",
         "globby": "^11.1.0",
         "is-glob": "^4.0.3",
@@ -2511,26 +2511,26 @@
       }
     },
     "@typescript-eslint/utils": {
-      "version": "5.25.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.25.0.tgz",
-      "integrity": "sha512-qNC9bhnz/n9Kba3yI6HQgQdBLuxDoMgdjzdhSInZh6NaDnFpTUlwNGxplUFWfY260Ya0TRPvkg9dd57qxrJI9g==",
+      "version": "5.27.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.27.1.tgz",
+      "integrity": "sha512-mZ9WEn1ZLDaVrhRaYgzbkXBkTPghPFsup8zDbbsYTxC5OmqrFE7skkKS/sraVsLP3TcT3Ki5CSyEFBRkLH/H/w==",
       "dev": true,
       "requires": {
         "@types/json-schema": "^7.0.9",
-        "@typescript-eslint/scope-manager": "5.25.0",
-        "@typescript-eslint/types": "5.25.0",
-        "@typescript-eslint/typescript-estree": "5.25.0",
+        "@typescript-eslint/scope-manager": "5.27.1",
+        "@typescript-eslint/types": "5.27.1",
+        "@typescript-eslint/typescript-estree": "5.27.1",
         "eslint-scope": "^5.1.1",
         "eslint-utils": "^3.0.0"
       }
     },
     "@typescript-eslint/visitor-keys": {
-      "version": "5.25.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.25.0.tgz",
-      "integrity": "sha512-yd26vFgMsC4h2dgX4+LR+GeicSKIfUvZREFLf3DDjZPtqgLx5AJZr6TetMNwFP9hcKreTTeztQYBTNbNoOycwA==",
+      "version": "5.27.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.27.1.tgz",
+      "integrity": "sha512-xYs6ffo01nhdJgPieyk7HAOpjhTsx7r/oB9LWEhwAXgwn33tkr+W8DI2ChboqhZlC4q3TC6geDYPoiX8ROqyOQ==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "5.25.0",
+        "@typescript-eslint/types": "5.27.1",
         "eslint-visitor-keys": "^3.3.0"
       }
     },
@@ -2893,12 +2893,12 @@
       "dev": true
     },
     "eslint": {
-      "version": "8.15.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.15.0.tgz",
-      "integrity": "sha512-GG5USZ1jhCu8HJkzGgeK8/+RGnHaNYZGrGDzUtigK3BsGESW/rs2az23XqE0WVwDxy1VRvvjSSGu5nB0Bu+6SA==",
+      "version": "8.17.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.17.0.tgz",
+      "integrity": "sha512-gq0m0BTJfci60Fz4nczYxNAlED+sMcihltndR8t9t1evnU/azx53x3t2UHXC/uRjcbvRw/XctpaNygSTcQD+Iw==",
       "dev": true,
       "requires": {
-        "@eslint/eslintrc": "^1.2.3",
+        "@eslint/eslintrc": "^1.3.0",
         "@humanwhocodes/config-array": "^0.9.2",
         "ajv": "^6.10.0",
         "chalk": "^4.0.0",
@@ -2916,7 +2916,7 @@
         "file-entry-cache": "^6.0.1",
         "functional-red-black-tree": "^1.0.1",
         "glob-parent": "^6.0.1",
-        "globals": "^13.6.0",
+        "globals": "^13.15.0",
         "ignore": "^5.2.0",
         "import-fresh": "^3.0.0",
         "imurmurhash": "^0.1.4",
@@ -3691,9 +3691,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "4.6.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.4.tgz",
-      "integrity": "sha512-9ia/jWHIEbo49HfjrLGfKbZSuWo9iTMwXO+Ca3pRsSpbsMbc7/IU8NKdCZVRRBafVPGnoJeFL76ZOAA84I9fEg==",
+      "version": "4.7.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.3.tgz",
+      "integrity": "sha512-WOkT3XYvrpXx4vMMqlD+8R8R37fZkjyLGlxavMc4iB8lrl8L0DeTcHbYgw/v0N/z9wAFsgBhcsF0ruoySS22mA==",
       "dev": true
     },
     "uri-js": {
@@ -3712,9 +3712,9 @@
       "dev": true
     },
     "vite": {
-      "version": "2.9.9",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-2.9.9.tgz",
-      "integrity": "sha512-ffaam+NgHfbEmfw/Vuh6BHKKlI/XIAhxE5QSS7gFLIngxg171mg1P3a4LSRME0z2ZU1ScxoKzphkipcYwSD5Ew==",
+      "version": "2.9.10",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-2.9.10.tgz",
+      "integrity": "sha512-TwZRuSMYjpTurLqXspct+HZE7ONiW9d+wSWgvADGxhDPPyoIcNywY+RX4ng+QpK30DCa1l/oZgi2PLZDibhzbQ==",
       "dev": true,
       "requires": {
         "esbuild": "^0.14.27",

--- a/package.json
+++ b/package.json
@@ -8,14 +8,14 @@
     "serve": "vite preview"
   },
   "devDependencies": {
-    "@typescript-eslint/eslint-plugin": "^5.25.0",
-    "@typescript-eslint/parser": "^5.25.0",
-    "eslint": "^8.15.0",
-    "typescript": "^4.6.4",
-    "vite": "^2.9.9"
+    "@typescript-eslint/eslint-plugin": "^5.27.1",
+    "@typescript-eslint/parser": "^5.27.1",
+    "eslint": "^8.17.0",
+    "typescript": "^4.7.3",
+    "vite": "^2.9.10"
   },
   "dependencies": {
     "@arcgis/core": "^4.23.7",
-    "@esri/calcite-components": "^1.0.0-beta.82"
+    "@esri/calcite-components": "^1.0.0-beta.83"
   }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -20,7 +20,7 @@ esriConfig.assetsPath =
   'https://cdn.jsdelivr.net/npm/@arcgis/core@4.23.7/assets'
 
 setAssetPath(
-  'https://cdn.jsdelivr.net/npm/@esri/calcite-components@1.0.0-beta.82/dist/calcite/assets'
+  'https://cdn.jsdelivr.net/npm/@esri/calcite-components@1.0.0-beta.83/dist/calcite/assets'
 )
 defineCustomElements()
 


### PR DESCRIPTION
@esri/calcite-components          ^1.0.0-beta.82  →  ^1.0.0-beta.83
@typescript-eslint/eslint-plugin         ^5.25.0  →         ^5.27.1
@typescript-eslint/parser                ^5.25.0  →         ^5.27.1
eslint                                   ^8.15.0  →         ^8.17.0
typescript                                ^4.6.4  →          ^4.7.3
vite                                      ^2.9.9  →         ^2.9.10